### PR TITLE
Fix excessive CPU load due to loop

### DIFF
--- a/src/Program.fs
+++ b/src/Program.fs
@@ -624,7 +624,7 @@ let watch (path:string) =
     fileSystemWatcher.IncludeSubdirectories <- false
     fileSystemWatcher.Changed.Add processFile
     fileSystemWatcher.Created.Add processFile
-    while true do ()
+    Threading.Thread.Sleep(Threading.Timeout.Infinite)
         
  
 [<EntryPoint>]


### PR DESCRIPTION
Hi,

I noticed that the eepassembler had an extremely high CPU utilization (~25%, one entire core!) and saw this was due to the `while true do ()` on line 626.

I have changed this to a `Threading.Thread.Sleep(Threading.Timeout.Infinite)`, and I have tested this to work on both Linux and Windows, and does not affect the file watcher in any way. I am not sure if this is the most "correct" way of fixing the issue though.

With this change it uses a negligible amount of CPU when running <0.01%.

Thanks.