### PR TITLE
Support `NOOP` alias

### DIFF
--- a/src/Program.fs
+++ b/src/Program.fs
@@ -141,6 +141,7 @@ let opMap: Map<string,Token> =
         "XSR", SHIFTOP 3
         "LDR", MEMOP 0
         "STR", MEMOP 2
+        "NOOP", JMPOP (0,true)
         "JMP", JMPOP (0,false)
         "EXT", EXTOP
         "JNE", JMPOP (1,true)


### PR DESCRIPTION
Not currently supported, is the negation of the JMP opcode